### PR TITLE
Add more ngx_lua builtin definitions.

### DIFF
--- a/src/luacheck/builtin_standards/ngx.lua
+++ b/src/luacheck/builtin_standards/ngx.lua
@@ -146,6 +146,8 @@ local ngx_defs = {
             set_var = {other_fields = true},
          },
       },
+      table = standards.def_fields("clear", "clone", "isarray", "isempty", "nkeys"),
+      thread = standards.def_fields("exdata"),
    },
 }
 


### PR DESCRIPTION
OpenResty has extended the standard LuaJIT in their LuaJIT fork:
https://github.com/openresty/luajit2