### PR TITLE
Fixes to use with Lua 5.4

### DIFF
--- a/luacheck-dev-1.rockspec
+++ b/luacheck-dev-1.rockspec
@@ -14,7 +14,7 @@ a few other typical problems within Lua programs.
    license = "MIT"
 }
 dependencies = {
-   "lua >= 5.1, < 5.4",
+   "lua >= 5.1",
    "argparse >= 0.6.0",
    "luafilesystem >= 1.6.3"
 }

--- a/src/luacheck/core_utils.lua
+++ b/src/luacheck/core_utils.lua
@@ -32,8 +32,8 @@ function core_utils.eval_const_node(node)
          return
       end
 
-      -- On Lua 5.3 convert to float to get same results as on Lua 5.1 and 5.2.
-      if _VERSION == "Lua 5.3" and not str:find("[%.eEpP]") then
+      -- On Lua 5.3+ convert to float to get same results as on Lua 5.1 and 5.2.
+      if (_VERSION == "Lua 5.3" or _VERSION == "Lua 5.4") and not str:find("[%.eEpP]") then
          str = str .. ".0"
       end
 

--- a/src/luacheck/stages/init.lua
+++ b/src/luacheck/stages/init.lua
@@ -31,7 +31,7 @@ stages.names = {
 stages.modules = {}
 
 for _, name in ipairs(stages.names) do
-   table.insert(stages.modules, require("luacheck.stages." .. name))
+   table.insert(stages.modules, (require("luacheck.stages." .. name)))
 end
 
 stages.warnings = {}


### PR DESCRIPTION
This fixes issues when running luacheck with Lua 5.4 and allow installing luacheck with Lua 5.4 on luarocks. However this is a not proper support for Lua 5.4, because luacheck in theory should parse the new Lua 5.4 syntax for `<close>` and `<const>` annotations, and consider the new lua 5.4 features when doing its static analysis.

I don't see much reason to lock away people from installing luacheck with Lua 5.4 as it works, so I've also removed the constrain in the dev luarocks file. That file is not even a proper release anyway and removing the constrain allow installing luacheck with lua 5.4 using raw github url on the file.